### PR TITLE
WIP: Update/test updates

### DIFF
--- a/crd-v1-testing/crd-test-helmrelease.yaml
+++ b/crd-v1-testing/crd-test-helmrelease.yaml
@@ -7,4 +7,4 @@ spec:
   chart:
     repository: http://chartmuseum-chartmuseum.default.svc.cluster.local:8080
     name: crd-test
-    version: 0.1.0
+    version: 0.2.0

--- a/crd-v1-testing/crd-test-helmrelease.yaml
+++ b/crd-v1-testing/crd-test-helmrelease.yaml
@@ -7,4 +7,4 @@ spec:
   chart:
     repository: http://chartmuseum-chartmuseum.default.svc.cluster.local:8080
     name: crd-test
-    version: 0.2.0
+    version: 0.2.1

--- a/crd-v1-testing/crd-test-helmrelease.yaml
+++ b/crd-v1-testing/crd-test-helmrelease.yaml
@@ -7,4 +7,4 @@ spec:
   chart:
     repository: http://chartmuseum-chartmuseum.default.svc.cluster.local:8080
     name: crd-test
-    version: 0.2.1
+    version: 0.2.2

--- a/crd-v1-testing/crd-test/Chart.yaml
+++ b/crd-v1-testing/crd-test/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: crd-test
 description: A Helm chart for Kubernetes
 type: application
-version: 0.2.1
+version: 0.2.2
 appVersion: "1.16.0"

--- a/crd-v1-testing/crd-test/Chart.yaml
+++ b/crd-v1-testing/crd-test/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: crd-test
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: "1.16.0"

--- a/crd-v1-testing/crd-test/Chart.yaml
+++ b/crd-v1-testing/crd-test/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: crd-test
 description: A Helm chart for Kubernetes
 type: application
-version: 0.2.0
+version: 0.2.1
 appVersion: "1.16.0"

--- a/crd-v1-testing/crd-test/crds/crd.yaml
+++ b/crd-v1-testing/crd-test/crds/crd.yaml
@@ -8,6 +8,19 @@ spec:
   - name: v1
     served: true
     storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              cronSpec:
+                type: string
+              image:
+                type: string
+              replicas:
+                type: integer
   scope: Namespaced
   names:
     plural: crddirs

--- a/crd-v1-testing/crd-test/crds/crd.yaml
+++ b/crd-v1-testing/crd-test/crds/crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: crddirs.crdtest.example.com
@@ -8,7 +8,6 @@ spec:
   - name: v1
     served: true
     storage: true
-  version: v1
   scope: Namespaced
   names:
     plural: crddirs

--- a/crd-v1-testing/crd-test/templates/crd.yaml
+++ b/crd-v1-testing/crd-test/templates/crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: templatedirs.crdtest.example.com
@@ -8,7 +8,19 @@ spec:
   - name: v1
     served: true
     storage: true
-  version: v1
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              cronSpec:
+                type: string
+              image:
+                type: string
+              replicas:
+                type: integer
   scope: Namespaced
   names:
     plural: templatedirs


### PR DESCRIPTION
Working on the examples provided in fluxcd/helm-operator#599 to make them a complete (successful) example of installing a CRD.

Since it won't do as a test, to have a `HelmRelease` that installs a beta CRD, when Kubernetes has removed the beta group for CustomResourceDefinition, we have to make sure our example chart is also CRD v1 compliant.

Some changes were needed there: we can no longer have an unstructured CRD that allows any spec without bounds, we have to provide an OpenAPI schema. (I just used the first OpenAPI schema from the Kubernetes CRD documentation page, this structure is not chosen for any other reason.)

Also the CRD v1 has `version` field removed in favor of `versions`. With these two changes, the other changes in fluxcd/helm-operator#599, the Role/ClusterRole/Binding changes added in fluxcd/helm-operator#618, I built an image from the source code in the current branch, and was able to confirm Helm Operator working to install CRDs in Kubernetes alpha for v1.22.0, (that is of course assuming that your chart containing the CRD has also been itself upgraded appropriately, as we do in this example via changes first attempted via 77f165d, then with other minor fixes added via 45e2d33 and 3e09baa.)

I didn't open this as a PR against Helm Operator itself, because in this case the error response we started with itself is a perfectly good test, and we can probably leave it how it is, unless we were also meaning to expand this into a real integrated end-to-end test. I wanted to see it working end-to-end with no errors at least once before I certified it as a release. I'm sure the e2e test updates in fluxcd/helm-operator#599 are fine and there's probably no need to add further testing to the suite.